### PR TITLE
[FEAT] 파일 업로드 및 로컬 저장 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ fabric.properties
 
 # ignore config file
 *.toml
+
+# ignore test data folder
+*/data

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,11 @@ type Config struct {
 		Uri string
 		Db  string
 	}
+
+	Storage struct {
+		Type     string
+		BasePath string // for local
+	}
 }
 
 func NewConfig(path string) *Config {

--- a/init/app/app.go
+++ b/init/app/app.go
@@ -5,6 +5,7 @@ import (
 	"Core/repository"
 	"Core/router"
 	"Core/service"
+	"Core/storage"
 )
 
 type App struct {
@@ -12,6 +13,7 @@ type App struct {
 	router     *router.Router
 	service    *service.Service
 	repository *repository.Repository
+	storage    storage.Storage
 }
 
 func NewApp(config *config.Config) {
@@ -20,10 +22,13 @@ func NewApp(config *config.Config) {
 	}
 
 	var err error
+	if app.storage, err = storage.NewStorage(config); err != nil {
+		panic(err)
+	}
 	if app.repository, err = repository.NewRepository(config); err != nil {
 		panic(err)
 	}
-	if app.service, err = service.NewService(config, app.repository); err != nil {
+	if app.service, err = service.NewService(config, app.repository, app.storage); err != nil {
 		panic(err)
 	}
 	if app.router, err = router.NewRouter(config, app.service); err != nil {

--- a/router/filerouter.go
+++ b/router/filerouter.go
@@ -1,0 +1,70 @@
+package router
+
+import (
+	"Core/service"
+	"github.com/gin-gonic/gin"
+	"mime/multipart"
+	"net/http"
+	"sync"
+)
+
+type FileRouter struct {
+	router  *Router
+	service *service.FileService
+}
+
+func InitFileRouter(router *Router, fileService *service.FileService) {
+	fr := &FileRouter{
+		router:  router,
+		service: fileService,
+	}
+
+	baseUri := "/file"
+	fr.router.POST(baseUri+"/upload", fr.uploadFile)
+}
+
+func (fr *FileRouter) uploadFile(c *gin.Context) {
+	var err error
+
+	// 요청 사이즈 확인
+	if err = c.Request.ParseMultipartForm(10 << 20); err != nil {
+		fr.router.GeneralResponse(c, http.StatusBadRequest, "Exceed file size", 0, "")
+		return
+	}
+
+	if files, ok := c.Request.MultipartForm.File["files"]; !ok || len(files) == 0 {
+		fr.router.GeneralResponse(c, http.StatusBadRequest, "No files uploaded", 0, "")
+		return
+	} else {
+		var wg sync.WaitGroup
+		errChan := make(chan error, len(files))
+
+		for _, fileHeader := range files {
+			wg.Add(1)
+			go func(fileHeader *multipart.FileHeader) {
+				defer wg.Done()
+				if file, gErr := fileHeader.Open(); gErr != nil {
+					errChan <- gErr
+					return
+				} else {
+					defer file.Close()
+					if gErr = fr.service.Save(fileHeader.Filename, file); gErr != nil {
+						errChan <- gErr
+					}
+				}
+			}(fileHeader)
+		}
+
+		wg.Wait()
+		close(errChan)
+
+		for err := range errChan {
+			if err != nil {
+				fr.router.GeneralResponse(c, http.StatusInternalServerError, "Error saving the file", 0, err.Error())
+				return
+			}
+		}
+
+		fr.router.GeneralResponse(c, http.StatusOK, "Success", 0, "")
+	}
+}

--- a/router/root.go
+++ b/router/root.go
@@ -4,24 +4,27 @@ import (
 	"Core/config"
 	"Core/service"
 	"github.com/gin-gonic/gin"
+	"net/http"
 )
 
 type Router struct {
-	config  *config.Config
-	engine  *gin.Engine
-	service *service.Service
+	config *config.Config
+	engine *gin.Engine
 }
 
 func NewRouter(config *config.Config, service *service.Service) (*Router, error) {
 	r := &Router{
-		config:  config,
-		engine:  gin.New(),
-		service: service,
+		config: config,
+		engine: gin.New(),
 	}
 
-	//r.engine.Use(requestTimeOutMiddleWare(5 * time.Second))
-	//
-	//NewMongoRouter(r, r.service.MService)
+	r.GET("/health", r.Health)
+
+	InitFileRouter(r, service.FileService)
 
 	return r, r.engine.Run(config.ServerInfo.Port)
+}
+
+func (r *Router) Health(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "UP"})
 }

--- a/router/utils.go
+++ b/router/utils.go
@@ -1,0 +1,40 @@
+package router
+
+import (
+	"Core/types"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+func (r *Router) GET(path string, handler ...gin.HandlerFunc) gin.IRoutes {
+	return r.engine.GET(path, handler...)
+}
+
+func (r *Router) POST(path string, handler ...gin.HandlerFunc) gin.IRoutes {
+	return r.engine.POST(path, handler...)
+}
+
+func (r *Router) PUT(path string, handler ...gin.HandlerFunc) gin.IRoutes {
+	return r.engine.PUT(path, handler...)
+}
+
+func (r *Router) DELETE(path string, handler ...gin.HandlerFunc) gin.IRoutes {
+	return r.engine.DELETE(path, handler...)
+}
+
+func (r *Router) GeneralResponse(c *gin.Context, code int, description string, errCode int, result interface{}) {
+	c.JSON(code, &types.GeneralResponse{
+		ResultCode:  code,
+		Description: description,
+		ErrCode:     errCode,
+		Result:      result,
+	})
+}
+
+func (r *Router) ResponseOK(c *gin.Context, response interface{}) {
+	c.JSON(http.StatusOK, response)
+}
+
+func (r *Router) ResponseErr(c *gin.Context, err ...interface{}) {
+	c.JSON(http.StatusInternalServerError, err)
+}

--- a/service/fileservice.go
+++ b/service/fileservice.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"Core/storage"
+	"errors"
+	"mime/multipart"
+	"path/filepath"
+	"slices"
+)
+
+type FileService struct {
+	storage storage.Storage
+}
+
+func NewFileService(storage storage.Storage) *FileService {
+	return &FileService{
+		storage: storage,
+	}
+}
+
+func (fs *FileService) Save(filename string, file multipart.File) error {
+	if err := validateFile(filename, file); err != nil {
+		return err
+	} else {
+		return fs.storage.Save(filename, file)
+	}
+}
+
+func validateFile(filename string, file multipart.File) error {
+	// 파일 이름 검증
+	// TODO : 허용 확장자 논의
+	allowedExtensions := []string{".jpg", ".png"}
+	ext := filepath.Ext(filename)
+
+	if !slices.Contains(allowedExtensions, ext) {
+		return errors.New("invalid file type")
+	} else {
+		return nil
+	}
+}

--- a/service/root.go
+++ b/service/root.go
@@ -3,17 +3,21 @@ package service
 import (
 	"Core/config"
 	"Core/repository"
+	"Core/storage"
 )
 
 type Service struct {
-	config     *config.Config
-	repository *repository.Repository
+	config      *config.Config
+	FileService *FileService
 }
 
-func NewService(config *config.Config, repository *repository.Repository) (*Service, error) {
+func NewService(
+	config *config.Config,
+	repository *repository.Repository,
+	storage storage.Storage) (*Service, error) {
 	r := &Service{
-		config:     config,
-		repository: repository,
+		config:      config,
+		FileService: NewFileService(storage),
 	}
 
 	return r, nil

--- a/storage/local.go
+++ b/storage/local.go
@@ -1,0 +1,48 @@
+package storage
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type LocalStorage struct {
+	basePath string
+}
+
+func NewLocalStorage(basePath string) *LocalStorage {
+	return &LocalStorage{
+		basePath: basePath,
+	}
+}
+
+func (s *LocalStorage) Save(filename string, file io.Reader) error {
+	fullPath := filepath.Join(s.basePath, filename)
+	var err error
+
+	// 생성된 디렉터리에 대해 777 권한 부여
+	if err = os.MkdirAll(filepath.Dir(fullPath), os.ModePerm); err != nil {
+		return err
+	}
+
+	if outFile, err := os.Create(fullPath); err != nil {
+		return err
+	} else {
+		defer outFile.Close()
+		if _, err = io.Copy(outFile, file); err != nil {
+			return err
+		} else {
+			return nil
+		}
+	}
+}
+
+func (s *LocalStorage) Delete(path string) error {
+	fullPath := filepath.Join(s.basePath, path)
+	return os.Remove(fullPath)
+}
+
+func (s *LocalStorage) Get(path string) (io.ReadCloser, error) {
+	fullPath := filepath.Join(s.basePath, path)
+	return os.Open(fullPath)
+}

--- a/storage/root.go
+++ b/storage/root.go
@@ -1,0 +1,30 @@
+package storage
+
+import (
+	"Core/config"
+	"errors"
+	"io"
+)
+
+const (
+	Local = "local"
+)
+
+type Storage interface {
+	Save(path string, file io.Reader) error
+	Delete(path string) error
+	Get(path string) (io.ReadCloser, error)
+}
+
+func NewStorage(config *config.Config) (Storage, error) {
+	switch config.Storage.Type {
+	case Local:
+		if basePath := config.Storage.BasePath; basePath == "" {
+			return nil, errors.New("missing basePath for local storage")
+		} else {
+			return NewLocalStorage(basePath), nil
+		}
+	default:
+		return nil, errors.New("unsupported storage type")
+	}
+}

--- a/types/responses.go
+++ b/types/responses.go
@@ -1,0 +1,8 @@
+package types
+
+type GeneralResponse struct {
+	ResultCode  int         `json:"resultCode"`
+	Description string      `json:"description"`
+	ErrCode     int         `json:"errCode"`
+	Result      interface{} `json:"result"`
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> related: #11 

## 📝작업 내용

> 파일 업로드 API 오픈
> 고루틴을 사용한 다중 파일 업로드 구현
> env.toml 설정 파일을 통해 로컬(추후 분산 파일 저장소로 개편 예정), S3(추후 기능 개발 및 S3 연동 예정) 저장소 선택 가능

## 💬리뷰 요구사항
> gin.context 내장 함수인 `SaveUploadedFile` 구현부를 가져와서 repository의 Save 메서드에 추가했습니다. 추후 Tagify와의 연동을 Service 파트에서 진행할 예정인데, context를 repository 파트까지 내리기도 애매하고, router 파트에서 모든걸 진행하기도 애매해서 필요한 함수의 구현부만 쏙 뽑아왔습니다, 혹시 좋은 의견 있으신지요?

<br>

SaveUploadedFile 구현부 추가
```go
// SaveUploadedFile uploads the form file to specific dst.
func (c *Context) SaveUploadedFile(file *multipart.FileHeader, dst string) error {
  src, err := file.Open()
  if err != nil {
    return err
  }
  defer src.Close()
  
  out, err := os.Create(dst)
  if err != nil {
    return err
  }
  defer out.Close()
  
  _, err = io.Copy(out, src)
  return err
}
```

close: #11 